### PR TITLE
Fix label in figure on Merkle Damgård Transformation

### DIFF
--- a/04-hashing.tex
+++ b/04-hashing.tex
@@ -223,7 +223,7 @@ Der Initialisierungsvektor IV wird dabei für jede Hashfunktion fest gewählt. A
 \put(36,6){\makebox(0,0)[cb]{$Z_1$}}
 
 \put(47,15){\vector(0,-1){7.5}}
-\put(50,10){\makebox(0,0)[cb]{$M_1$}}
+\put(50,10){\makebox(0,0)[cb]{$M_2$}}
 
 \put(42,2.5){\framebox(10,5){$F$}}
 


### PR DESCRIPTION
Figure 4.1 should be

```
    M1    M2
    v     v
––> F ––> F ––> …
IV    Z1    Z2
```

instead of (note the `M2`)

```
    M1    M1
    v     v
––> F ––> F ––> …
IV    Z1    Z2
```
