### PR TITLE
Sicherheitsm. für Ident. benutzt Variable zweimal

### DIFF
--- a/09-identifikation.tex
+++ b/09-identifikation.tex
@@ -53,8 +53,8 @@ sind zustandsbehaftet und interagieren während des Identitätsnachweises mitein
 \begin{enumerate}
   \item V erhält den öffentlichen Schlüssel $\pkey_P$ als Eingabe und gibt $\mathrm{out}_V$ aus
   \item P erhält Vs Ausgabe $\mathrm{out}_V$ und den privaten Schlüssel $\skey_P$ und gibt $\mathrm{out}_P$ aus
-  \item V erhält Ps Ausgabe $\mathrm{out}_P$ und gibt $\mathrm{out}_V$ aus
-  \item ist $\mathrm{out}_V \in \{0,1\}$ beende die Interaktion, ansonsten springe zurück zu Schritt 2
+  \item V erhält Ps Ausgabe $\mathrm{out}_P$ und gibt $\mathrm{out}_V'$ aus
+  \item ist $\mathrm{out}_V' \in \{0,1\}$ beende die Interaktion, ansonsten springe zurück zu Schritt 2
 \end{enumerate}
 Der Verifier erzeugt also eine Ausgabe, mit deren Hilfe P beweisen muss, dass er das Geheimis $\skey$ kennt. P liefert auf Basis des Geheimnisses und der
 Ausgabe von V seinerseits eine Ausgabe und gibt diese an V weiter. V prüft das Ergebnis und entscheidet, ob die Prüfung erfolgreich abgeschlossen wurde. Falls ja, gibt


### PR DESCRIPTION
Im Sicherheitsmodell für Identifikationsprotokolle wird "out_V" zweimal verwendet.
Jetzt hat die 2. Benutzung Striche um den Unterschied kenntlich zu machen.
