### PR TITLE
Leerzeichen-Fix (fixes #33)

### DIFF
--- a/02-symencryption.tex
+++ b/02-symencryption.tex
@@ -1300,7 +1300,7 @@ staatlicher Dokumente der höchsten Geheimhaltungsstufe zugelassen.
 
 \subsection{Angriffe auf Blockchiffren}
 \subsubsection{Lineare Kryptoanalyse}\label{sssec:linKryptoanalyse}
-Die \emph{lineare Kryptoanalyse}\indexLinCrypt  \: stellt einen Angriff auf
+Die \emph{lineare Kryptoanalyse} \indexLinCrypt stellt einen Angriff auf
 Blockchiffren dar, der meist besser als die vollständige Suche über dem
 Schlüsselraum ist. Ziel dieser Angriffsmethode ist es, lineare
 Abhängigkeiten 
@@ -1333,7 +1333,7 @@ Gleichung~\ref{approx} an. Wenn eine effektive lineare Approximation
 bekannt ist, kann mit der naiven Maximum-Likelihood-Methode ein
 Schlüsselbit $\key[k_1,\dots, k_c]$ erraten werden. 
 
-Bei Verschlüsselungssystemen, welche die Feistel-Struktur\indexFeistel
+Bei Verschlüsselungssystemen, welche die Feistel-Struktur \indexFeistel
 verwenden, sehen entsprechende Angriffe wie folgt aus: 
 \begin{enumerate}
 \item Finde lineare Abhängigkeiten zwischen Ein- und Ausgabe.


### PR DESCRIPTION
Fehlende Leerzeichen zwischen Wörtern, zwischen denen eine Indexierug stattfindet, eingefügt.