### PR TITLE
Alle Vorkommen von ':=', die ein Definitions-Symbol darstellen sollen…

### DIFF
--- a/02-symencryption.tex
+++ b/02-symencryption.tex
@@ -543,7 +543,7 @@ ergibt sich beispielhaft folgendes Schema:
     \multicolumn{1}{c}{\(\downarrow\cdot\alpha_k\)} & \\
     \multicolumn{1}{c}{} &
     \multicolumn{1}{c}{} &
-    \multicolumn{5}{c}{\(\xlongrightarrow{\qquad\qquad\qquad\qquad\qquad\qquad}\ \key_{k+1}:=\sum_{j=1}^{k}\alpha_{j}\key_{j} \mod 2\)}
+    \multicolumn{5}{c}{\(\xlongrightarrow{\qquad\qquad\qquad\qquad\qquad\qquad}\ \key_{k+1}\coloneqq\sum_{j=1}^{k}\alpha_{j}\key_{j} \mod 2\)}
 \end{tabular}
 \]
 
@@ -560,7 +560,7 @@ ergibt sich beispielhaft folgendes Schema:
     \multicolumn{1}{c}{\hphantom{\(\downarrow\cdot\alpha_k\)}} & \\
     \multicolumn{1}{c}{} &
     \multicolumn{1}{c}{} &
-    \multicolumn{5}{c}{\hphantom{\(\xlongrightarrow{\qquad\qquad\qquad\qquad\qquad\qquad}\ \key_{k+1}:=\sum_{j=1}^{k}\alpha_{j}\key_{j} \mod 2\)}}
+    \multicolumn{5}{c}{\hphantom{\(\xlongrightarrow{\qquad\qquad\qquad\qquad\qquad\qquad}\ \key_{k+1}\coloneqq\sum_{j=1}^{k}\alpha_{j}\key_{j} \mod 2\)}}
 \end{tabular}
 \]
 Wählen wir für die Zustände $\key^{(i)}$ des LFSR die Gestalt $(\key_{1
@@ -568,7 +568,7 @@ Wählen wir für die Zustände $\key^{(i)}$ des LFSR die Gestalt $(\key_{1
 folgt darstellen: 
 \begin{align*}
   \key^{(i+1)} = A \cdot \key^{(i)} \text{,} \; \;
-  A := \begin{pmatrix}
+  A \coloneqq \begin{pmatrix}
     0 & 1 & 0 & \cdots & 0 \\
     0 & 0 & 1 & & 0 \\
     \vdots & \vdots & & \ddots & \\

--- a/03-definition.tex
+++ b/03-definition.tex
@@ -156,7 +156,7 @@ selbstgewählten Klartexten nicht unterscheiden.
   \begin{enumerate}
   \item $\A$ wählt zwei Nachrichten $\plaint_1, \plaint_2$
     gleicher Länge.
-  \item $\A$ erhält $\ciphert^{*} := \enc(\key,
+  \item $\A$ erhält $\ciphert^{*} \coloneqq \enc(\key,
     \plaint_{b})$ für ein von $\C$ zufällig gleichverteilt gewähltes $b \in
     \{1, 2\}$.
   \item $\A$ gewinnt, wenn er $b$ korrekt errät.
@@ -229,7 +229,7 @@ bezeichnen.
   \begin{itemize}
   \item $\A$ wählt zwei Klartextblöcke $\plaint_1 \neq
     \plaint_2$ beliebig.
-  \item $\A$ erhält $\ciphert^{*} := \enc(\key,
+  \item $\A$ erhält $\ciphert^{*} \coloneqq \enc(\key,
     \plaint_{b})$ für ein von $\C$ zufällig gleichverteilt gewähltes $b \in
     \{1, 2\}$.
   \item $\A$ erfragt $\ciphert_1 = \enc(\key, \plaint_1)$

--- a/04-hashing.tex
+++ b/04-hashing.tex
@@ -40,7 +40,7 @@ wenn jeder PPT-Algorithmus nur mit höchstens in $k$ vernachlässigbarer
 Wahrscheinlichkeit eine Kollision findet.  Präziser formuliert ist der
 Vorteil für jeden PPT-Angreifer $\A$
 \begin{align*}
-Adv^{cr}_{H,\A}(k):= \Pr \left[ (X, X') \leftarrow \A(1^k) : X \neq X'
+Adv^{cr}_{H,\A}(k)\coloneqq \Pr \left[ (X, X') \leftarrow \A(1^k) : X \neq X'
   \land H_k(X) = H_k(X')\right] 
 \end{align*}
 in $k$ vernachlässigbar.
@@ -69,7 +69,7 @@ jeder PPT-Algorithmus nur mit höchstens in $k$ vernachlässigbarer
 Wahrscheinlichkeit ein Urbild eines gegebenen, aus $\chi_k$ bezogenen
 Bildes findet. Genauer ist der Vorteil für jeden PPT-Angreifer $\A$
 \begin{equation*}
-Adv^{ow}_{H,\A}(k):= \Pr \left[ X' \leftarrow \A(H(X), 1^k) : H(X) = H(X')\right]
+Adv^{ow}_{H,\A}(k)\coloneqq \Pr \left[ X' \leftarrow \A(H(X), 1^k) : H(X) = H(X')\right]
 \end{equation*} 
 in $k$ vernachlässigbar, wobei $X \leftarrow \chi_k$ gewählt
 wurde. Dabei muss $\A$ nicht zwingend $X' = X$ zurückgeben.
@@ -142,7 +142,7 @@ Eine über $k$ parametrisierte Funktion $H$ genügt der Target Collision
 Resistance\indexTargetCollisionResistance, falls für jeden PPT-Angreifer
 $\A$ bei gegebenem, zufällig gezogenem $X$ die Wahrscheinlichkeit
 \begin{equation*}
-Adv^{tcr}_{H,\A}(k):= \Pr \left[ X' \leftarrow \A(X, 1^k) : X \neq X'
+Adv^{tcr}_{H,\A}(k)\coloneqq \Pr \left[ X' \leftarrow \A(X, 1^k) : X \neq X'
   \land H_k(X) = H_k(X')\right] 
 \end{equation*}
 in $k$ vernachlässigbar ist.

--- a/05-asymmenc.tex
+++ b/05-asymmenc.tex
@@ -72,7 +72,7 @@ asymmetrischen Verfahren Anwendung:
   \begin{enumerate}
   \item $\A$ wählt zwei Nachrichten $\plaint_1$, $\plaint_2$ gleicher
     Länge.
-  \item $\A$ erhält $\ciphert^{*} := \enc(pk, \plaint_{b})$ für ein von
+  \item $\A$ erhält $\ciphert^{*} \coloneqq \enc(pk, \plaint_{b})$ für ein von
     $\C$ zufällig gleichverteilt gewähltes $b \in \{1, 2\}$.
   \item $\A$ gewinnt, wenn er $b$ korrekt errät.
   \end{enumerate} Ein asymmetrisches Verfahren $(\gen, \enc, \dec)$
@@ -191,7 +191,7 @@ des öffentlichen und privaten Schlüssels funktioniert folgendermaßen:
 \item Berechne $\varphi(N) = (P - 1)(Q - 1)$\footnote{$\varphi$
     bezeichnet die Eulersche Phi-Funktion\indexEulerPhiFunction. Sie gibt
     für jede natürliche Zahl n an, wie viele zu n teilerfremde natürliche
-    Zahlen es gibt, die nicht größer als n sind: $\varphi(n) := \vert
+    Zahlen es gibt, die nicht größer als n sind: $\varphi(n) \coloneqq \vert
     \{a\in\N \, |\, 1 \le a \le n \land \operatorname{ggT}(a,n) = 1 \}
     \vert$. Insbesondere ist $\varphi(N)$ die Anzahl multiplikativ
     invertierbarer Elemente im Restklassenring $\mathbb{Z}/N\mathbb{Z}$.
@@ -466,7 +466,7 @@ macht sich die Schwierigkeit zunutze, das DLOG-Problem\indexDLOGProblem,
 also die Berechnung von diskreten Logarithmen in zyklischen Gruppen, zu
 lösen. Unter einer zyklischen Gruppe versteht man eine Gruppe
 $\mathbbm{G}$, bei der ein sogenanntes Erzeugerelement $g$ existiert, so
-dass $\mathbbm{G} = \langle g \rangle := \{g^k \mid k \in
+dass $\mathbbm{G} = \langle g \rangle \coloneqq \{g^k \mid k \in
 \mathbbm{Z}\}$.
 
 \subsection{Vorgehen} Für die Schlüsselerzeugung wird eine ausreichend

--- a/06-symauth.tex
+++ b/06-symauth.tex
@@ -205,7 +205,7 @@ möglichst zufällig auf ihre Urbilder zu verteilen.
   Funktion. $PRF$ heißt Pseudorandom Function (PRF), falls für jeden
   PPT-Algorithmus $\mathcal{A}$ die Funktion
   \begin{equation*}
-    \text{Adv}_{\text{\textit{PRF}},\mathcal{A}}^{prf}(k) := \Pr \lbrack
+    \text{Adv}_{\text{\textit{PRF}},\mathcal{A}}^{prf}(k) \coloneqq \Pr \lbrack
     \mathcal{A}^{\text{\textit{PRF}}(K,\cdot)}(1^k) = 1 \rbrack - \Pr
     \lbrack \mathcal{A}^{R(\cdot)}(1^k) = 1 \rbrack
   \end{equation*} vernachlässigbar im Sicherheitsparameter $k$ ist,

--- a/07-asymmauth.tex
+++ b/07-asymmauth.tex
@@ -117,7 +117,7 @@ besprochen wurde:
 \item Berechne $\varphi(N) = (P - 1)(Q - 1)$\footnote{$\varphi$
     bezeichnet die Eulersche Phi-Funktion. Sie gibt für jede natürliche Zahl
     n an, wie viele zu n teilerfremde natürliche Zahlen es gibt, die nicht
-    größer als n sind: $\varphi(n) := \vert \{a\in\N \, |\, 1 \le a \le n
+    größer als n sind: $\varphi(n) \coloneqq \vert \{a\in\N \, |\, 1 \le a \le n
     \land \operatorname{ggT}(a,n) = 1 \} \vert$. Insbesondere ist
     $\varphi(N)$ die Anzahl multiplikativ invertierbarer Elemente im
     Restklassenring $\mathbb{Z}/N\mathbb{Z}$.  Sie ist multiplikativ,
@@ -148,7 +148,7 @@ Das Verfahren hat jedoch einige Nachteile:
   wählt zunächst ein beliebiges $\sigma \in \mathbbm{Z}$. Dann kann er
   mithilfe des öffentlichen Schlüssels $\pkey$ zu dieser Signatur einfach
   ein $\plaint$ generieren, zu dem die Signatur $\sigma$ passt: $\plaint
-  := \sigma^e \mod N$.\\ Zwar ist für diesen Angriff im ersten Moment
+  \coloneqq \sigma^e \mod N$.\\ Zwar ist für diesen Angriff im ersten Moment
   keine sinnvolle Nutzung ersichtlich, da der Angreifer keine Kontrolle
   darüber hat, für welche Nachricht er eine Signatur fälscht, die
   Problematik eines Missbrauchs besteht jedoch prinzipiell. Dieser Angriff
@@ -243,8 +243,8 @@ g^x)$.  Für die Signaturerzeugung wird eine zufällige, in $\Z{p}$
 invertierbare Zahl $e \in \{1, \dots, p - 1\}$ gewählt, wobei
 $p-1=|\G|$. Damit berechnet man
 \begin{align*} 
-  a &:= g^e \in \G\\ 
-  b &:= (M - a \cdot x) \cdot e^{-1} \mod |G|
+  a &\coloneqq g^e \in \G\\ 
+  b &\coloneqq (M - a \cdot x) \cdot e^{-1} \mod |G|
 \end{align*} 
 $a$ wird je nach Kontext als Gruppenelement oder als Zahl interpretiert,
 $b$ ist eine Zahl in $\Z{p}$.  Damit gilt $a \cdot x + e \cdot b =
@@ -287,7 +287,7 @@ Angriffspunkte:
   der Parameter ist es möglich, auch ohne Kenntnis des Schlüssels $x$
   gültige Signaturen zu erzeugen. Wähle zunächst $c$ zufällig. Setze
   außerdem:
-  \begin{align*} a &:= g^cg^x = g^{c+x}\\ b &:= -a
+  \begin{align*} a &\coloneqq g^cg^x = g^{c+x}\\ b &\coloneqq -a
   \end{align*} Dies impliziert $e=c+x$.  Dann ist $(a, b)$ eine
   gültige Signatur zu $M$ mit
   \begin{align*} M &= -ac\\ &= a \cdot x - a \cdot (c + x)\\ &= a
@@ -311,9 +311,9 @@ wird $x=11$ gewählt. Es sind also $\skey = (\G, 3, 11)$ und $\pkey =
 invertierbaren Exponenten $e= 13$ und berechnet mit dem
 erw. Euklidischen Algorithmus $e^{-1}=5$. Dann ist $\sigma = (a, b)$ mit
 \begin{align*} 
-  a &:= g^e &\\ 
+  a &\coloneqq g^e &\\ 
     &= 3^{13} \equiv 12 & \mod 17\\ 
-  b &:= (\plaint-a \cdot x) \cdot e^{-1} & \mod |\G|\\
+  b &\coloneqq (\plaint-a \cdot x) \cdot e^{-1} & \mod |\G|\\
     &= (10 - 11 \cdot 12) \cdot 13^{-1} & \mod 16\\
     &\equiv (10 - 11\cdot 12) \cdot 5 \equiv 14 & \mod 16
 \end{align*}
@@ -356,8 +356,8 @@ ElGamal-Signaturverfahren entsteht unter Verwendung einer
 kollisionsresistenten Hashfunktion $H$ der
 \emph{Digital Signature Algorithm} (DSA):
 \begin{align*} 
-  a &:= g^e\\ 
-  b &:= (H(M) - a \cdot x) \cdot e^{-1} \mod \left|\G\right|
+  a &\coloneqq g^e\\ 
+  b &\coloneqq (H(M) - a \cdot x) \cdot e^{-1} \mod \left|\G\right|
 \end{align*} 
 mit der Signatur $\sigma = (a,b)$.
 

--- a/08-keyexchange.tex
+++ b/08-keyexchange.tex
@@ -142,7 +142,7 @@ Bob zu senden (siehe Abb.
 \begin{picture}(30,10)
 \put(0,2){\makebox(0,0)[cb]{$\text{Alice}_{\skey_A}$}}
 \put(10,3){\vector(1,0){40}}
-\put(30,4){\makebox(0,0)[cb]{$C := \enc(\pkey_B, \key)$}}
+\put(30,4){\makebox(0,0)[cb]{$C \coloneqq \enc(\pkey_B, \key)$}}
 \put(55,0.5){\makebox(10,5){$\text{Bob}_{\skey_B}$}}
 \end{picture}
 \end{center}
@@ -173,8 +173,8 @@ sofort auffällt.
 \begin{picture}(120,10)(-15,0)
 \put(0,0){\makebox(0,0)[cb]{$\text{Alice}_{\skey_{\text{PKE,}A}, \skey_{\sig, A}}$}}
 \put(16,3){\vector(1,0){80}}
-\put(55,4){\makebox(0,0)[cb]{$(C := \enc(\pkey_{\text{PKE,}B}, \key),$}}
-\put(55,-2){\makebox(0,0)[cb]{$\sigma := \sig(\skey_{\sig, A}, C))$}}
+\put(55,4){\makebox(0,0)[cb]{$(C \coloneqq \enc(\pkey_{\text{PKE,}B}, \key),$}}
+\put(55,-2){\makebox(0,0)[cb]{$\sigma \coloneqq \sig(\skey_{\sig, A}, C))$}}
 \put(110,0){\makebox(10,5){$\text{Bob}_{\skey_{\text{PKE,}B}, \skey_{\sig, B}}$}}
 \end{picture}
 \end{center}
@@ -517,7 +517,7 @@ Kommunikation verwendeten Schlüssel zu erlangen.
   \end{align*} Klar ist, dass $K$ vergleichsweise kurz
   sein und deshalb mit vielen Nullbits beginnen muss. Ziel ist es nun,
   möglichst viele gültige Faktoren $\alpha_i$ zu finden, sodass
-  \begin{align*} M_i := \alpha_i \cdot
+  \begin{align*} M_i \coloneqq \alpha_i \cdot
     (0\mathrm{x}0002 \parallel \mathtt{rnd} \parallel
     0\mathrm{x}00 \parallel K) \mod N = \dec(\alpha_i^e \cdot C \mod N)
   \end{align*} gültig ist. Die Gültigkeit wird
@@ -537,7 +537,7 @@ besagt, dass jedes Bit von RSA \emph{hardcore} ist.
 beliebig. Sei $\mathcal{O}$ ein Orakel, das bei Eingabe $C$ das i-te Bit
 von $M = C^d \mod N$ ausgibt. Dann existiert ein (von N, e, d
 unabhängiger) Polynomialzeit-Algorithmus, der bei Eingabe N, e, i und
-$C^* := (M^*)^e \mod N$ und mit $\mathcal{O}$-Zugriff $M^*$ berechnet.
+$C^* \coloneqq (M^*)^e \mod N$ und mit $\mathcal{O}$-Zugriff $M^*$ berechnet.
 \end{theorem}
 
 \subsubsection{CRIME}
@@ -565,7 +565,7 @@ eingeschalteter Kompression.
   (z.B. \texttt{WXYZ}) diktieren, die dieser vor dem Verschlüsseln der
   Nachricht hinzufügt. Er komprimiert und verschlüsselt also nicht mehr
   nur \texttt{ABCD} sondern \texttt{WXYZABCD}. Aus dem belauschten
-  Chiffrat $C := \enc(K, \mathit{comp}(\mathtt{WXYZABCD}))$ kann der
+  Chiffrat $C \coloneqq \enc(K, \mathit{comp}(\mathtt{WXYZABCD}))$ kann der
   Angreifer die Länge von $\mathit{comp}(\mathtt{WXYZABCD})$ extrahieren
   und so den Abstand seines eingeschleusten Textstücks \texttt{WXYZ} zu
   dem vom Client geheim gehaltenen Cookie bestimmen.

--- a/09-identifikation.tex
+++ b/09-identifikation.tex
@@ -27,7 +27,7 @@ sein kann, dass der Prover das Geheimnis kennt, der Verifier selbst
 jedoch $\skey$ nicht lernt.
 
 Ein zweiter Versuch umfasst die bereits entwickelten
-Signaturschemata. Der Prover schickt $\sigma := \sig(\skey_A,
+Signaturschemata. Der Prover schickt $\sigma \coloneqq \sig(\skey_A,
 \text{"`ich bin's, P"'})$ an den Verifier.  $\ver(\pkey_A,\text{"`ich
 bin's, P"'}, \sigma)$ liefert dem Verifier die Gültigkeit der
 entsprechenden Signatur und damit die Identität des Absenders. Die Idee
@@ -56,7 +56,7 @@ in Kapitel \ref{sec:id:protokolle} näher betrachtet.
 
       \put(50,10){\vector(-1,0){40}} \put(30,11){\makebox(0,0)[cb]{$R$}}
       
-      \put(10,3){\vector(1,0){40}} \put(30,4){\makebox(0,0)[cb]{$\sigma :=
+      \put(10,3){\vector(1,0){40}} \put(30,4){\makebox(0,0)[cb]{$\sigma \coloneqq
           \sig(\skey_A, R)$}}
     \end{picture}
   \end{center}
@@ -191,7 +191,7 @@ PK-Identifikationsprotokoll $(\gen, \mathrm{P}, \mathrm{V})$
 PK-Identifikationsprotokoll bricht. Dann ist er in der Lage,
 nicht-vernachlässigbar oft aus dem öffentlichen Schlüssel $\pkey_{i^*}$
 und einer vom Verifier ausgewählten Zufallszahl $R$ eine Signatur
-$\sigma := \sig(\skey_{i^*}, R)$ zu berechnen.
+$\sigma \coloneqq \sig(\skey_{i^*}, R)$ zu berechnen.
 
 Aus $A$ kann nun ein Angreifer $B$ konstruiert werden, der die
 Ergebnisse von $A$ nutzt, um das EUF-CMA-sichere Signaturverfahren zu

--- a/10-zeroknowledge.tex
+++ b/10-zeroknowledge.tex
@@ -67,7 +67,7 @@ sendet P eine Signatur der Nachricht R an V zurück.
 
 Um ein glaubwürdiges simuliertes Transkript zu erstellen müsste der
 Simulator also einen Zufallsstring R und eine gültige Signatur $\sigma
-:= \sig(\skey, R)$ erzeugen, um diese in das simulierte Transkript
+\coloneqq \sig(\skey, R)$ erzeugen, um diese in das simulierte Transkript
 einzubetten. Das würde aber einen Bruch des Signaturverfahrens
 erfordern, da $\Sim$ nur über $\pkey$ verfügt. Das Protokoll ist also
 \emph{nicht} Zero-Knowledge.

--- a/13-protokolle.tex
+++ b/13-protokolle.tex
@@ -145,7 +145,7 @@ Auch dieser Ansatz stößt aber an gewisse Grenzen, wie folgendes Beispiel zeigt
 				\advA\quad\\
 				\uparrow C\\
 				\texttt{Alice}_{\pkey_B}\quad
-				\xlongrightarrow{\qquad C:=\enc(\pkey_B,M)\qquad}
+				\xlongrightarrow{\qquad C\coloneqq\enc(\pkey_B,M)\qquad}
 				\quad\texttt{Bob}_{\skey_B}\\
 				\quad\uparrow M\qquad\qquad\qquad\qquad\qquad\qquad\qquad\downarrow M
 			\end{gather*}

--- a/a-gruppen.tex
+++ b/a-gruppen.tex
@@ -102,8 +102,8 @@ vertieft werden sollen.
 \end{definition}
 
 \begin{beispiel}
-  Wir haben gesehen, dass $\G := (\Z{}, +)$ eine Gruppe ist. Es sei
-  $\Z{g}$ die Menge der geraden Zahlen. Dann ist $\mathbbm{U} := (\Z{g},
+  Wir haben gesehen, dass $\G \coloneqq (\Z{}, +)$ eine Gruppe ist. Es sei
+  $\Z{g}$ die Menge der geraden Zahlen. Dann ist $\mathbbm{U} \coloneqq (\Z{g},
   +)$ eine Untergruppe von $\G$:
   \begin{itemize}
   \item Es ist $\mathbb{U} \subset \G$, weil die geraden Zahlen eine
@@ -231,7 +231,7 @@ also als Elemente die Äquivalenzklassen der Zahlen von $1$ bis $p-1$.
 
 \begin{beispiel}
 \label{bsp:azyklische_gruppe}
-Betrachten wir die Gruppe $\G := (\Z{8}, \cdot)$. Zunächst prüfen wir, welche
+Betrachten wir die Gruppe $\G \coloneqq (\Z{8}, \cdot)$. Zunächst prüfen wir, welche
 Elemente die Gruppe hat:
 \begin{eqnarray*}
 ggT(1, 8) = 1 \rightarrow 1 \in \G\\
@@ -261,7 +261,7 @@ Die Gruppe $\G$ hat also keinen Erzeuger, ist also nicht zyklisch.
 \end{beispiel}
 
 \begin{beispiel}
-  Analog zu Beispiel \ref{bsp:azyklische_gruppe} prüfen wir, ob $\G :=
+  Analog zu Beispiel \ref{bsp:azyklische_gruppe} prüfen wir, ob $\G \coloneqq
   (\Z{7}, \cdot)$ zyklisch ist. $\G$ hat die Elemente $\{1, 2, 3, 4, 5,
   6\}$.
 

--- a/seitenkanalangriffe.tex
+++ b/seitenkanalangriffe.tex
@@ -109,9 +109,9 @@ simuliert er den Algorithmus für alle $X$ aus seinen
 Trace-Message-Paaren und sortiert die Eingaben in zwei Gruppen \calL,
 \calH, wobei
 \begin{eqnarray*}
-\calL & := &\{X| \texttt{Simulation mit $X$ hat einen niedrigen
+\calL & \coloneqq &\{X| \texttt{Simulation mit $X$ hat einen niedrigen
   Stromverbrauch}\},\\
-\calH & := &\{X| \texttt{Simulation mit $X$ hat einen hohen
+\calH & \coloneqq &\{X| \texttt{Simulation mit $X$ hat einen hohen
   Stromverbrauch}\}.
 \end{eqnarray*}
 Anschließend betrachtet der Angreifer den durchschnittlichen


### PR DESCRIPTION
…, durch ein Definitions-Symbole ersetzt.