### PR TITLE
Einfügen von Fußnote und Quelle dass SHA-1 auch praktisch gebrochen wurde

### DIFF
--- a/04-hashing.tex
+++ b/04-hashing.tex
@@ -505,7 +505,7 @@ Merkle-Damgård-Konstrukt beruht und für eine Vielzahl kryptographischer
 Anwendungen und Datenintegritäts-Sicherung eingesetzt wurde. Von der
 Verwendung von MD5 sollte für sicherheitsrelevante Anwendungsszenarien
 mittlerweile jedoch abgesehen werden: Im Unterschied zu SHA-1 können bei
-MD5 explizite Kollisionen gefunden werden. Im Jahr 2013 stellten Xie
+MD5 explizite Kollisionen gefunden werden\footnote{Tatsächlich wurde SHA-1 im Jahre 2017 auch praktisch gebrochen \cite{Stevens2017}. Interessierte können unter \url{www.shattered.io} mehr darüber erfahren.}. Im Jahr 2013 stellten Xie
 Tao, Fanbao Liu und Dengguo Feng den bis dato besten Angriff vor, der
 aus einer Menge von etwa $2^{18}$ MD5 Hashwerten ein Kollisionspaar
 findet. Heutige Prozessoren benötigen dafür weniger als eine Sekunde.

--- a/literature.bib
+++ b/literature.bib
@@ -257,6 +257,14 @@ misc{NIST_BlockModes,
 	howpublished={\url{http://www.sophos.com/en-us/threat-center/threat-analyses/viruses-and-spyware/JS~Spacehero-A/detailed-analysis.aspx}}
 }
 
+@misc{Stevens2017,
+    author = {Marc Stevens and Elie Bursztein and Pierre Karpman and Ange Albertini and Yarik Markov},
+    title = {The first collision for full SHA-1},
+    howpublished = {Cryptology ePrint Archive, Report 2017/190},
+    year = {2017},
+    note = {\url{http://eprint.iacr.org/2017/190}},
+}
+
 @booklet{Geiselmann2016,
         author={Willi Geiselmann and Daniel Kraschewski},
         title={Symmetrische Verschlüsselungsverfahren},


### PR DESCRIPTION
SHA-1 wurde in einem praktischen Angriff, der 100000 mal schneller als Bruteforce ist, gebrochen.
Details sind [hier](http://shattered.io/) und [hier](http://shattered.io/static/shattered.pdf
) zu finden.
Ich habe dazu eine Fußnote, sowie eine Quelle eingefügt.