### PR TITLE
Voraussetzung Gruppenordnung prim (und Typo)

### DIFF
--- a/05-asymmenc.tex
+++ b/05-asymmenc.tex
@@ -542,8 +542,9 @@ aufgefasst. Wir wählen $p > 2 $ prim und setzen $\mathbbm{G} \subset
 \mathbbm{Z}^*_p$ als Untergruppe der Quadrate\footnote{Die Untergruppe
   der Quadrate von $\mathbbm{Z}^*_p$ besteht aus den Elementen $\{x^2
   \text{ mod } p\ \vert\ x \in \mathbbm{Z}^*_p\}$. Falls $p > 2$ prim ist,
-  besteht diese Untergruppe aus $\frac{p - 1}{2}$ Elementen. Jedes
-  Element, mit Ausnahme der Eins, kann als Gruppenerzeuger dienen.} von
+  besteht diese Untergruppe aus $\frac{p - 1}{2}$ Elementen. Falls
+  $\frac{p - 1}{2}$ ebenfalls prim ist, kann jedes Element, mit Ausnahme
+  der Eins, als Gruppenerzeuger dienen.} von
 $\mathbbm{Z}^*_p$, wobei $\mathbbm{G}$ die Ordnung $q = \frac{(p -
   1)}{2}$ hat.  Es sei $n$ die Länge des Bit-Strings der Gruppenordnung
 $q$. Dann können wir die Nachricht $M \in \{0, 1\}^{n - 1}$ beliebig

--- a/09-identifikation.tex
+++ b/09-identifikation.tex
@@ -158,7 +158,7 @@ $(\pkey, \skey)$-Paare mithilfe des $\gen$-Algorithmus und ordnet die privaten S
 \begin{enumerate}
   \item $\A$ darf nun mit beliebig vielen dieser gültigen Prover
     interagieren. Dabei nimmt er die Rolle des Verifiers ein und hat demnach
-    9Zugriff auf die passenden öffentlichen Schlüssel $\pkey_i$, während die
+    Zugriff auf die passenden öffentlichen Schlüssel $\pkey_i$, während die
     gültigen Prover seine Anfragen mit ihren privaten Schlüsseln $\skey_i$
     beantworten.
   \item $\A$ wählt sich nun einen der $\pkey_{i}$ aus und gibt sich


### PR DESCRIPTION
Dass jedes Element, außer dem Neutralen, ein Erzeuger der Gruppe ist gilt nur für Gruppen mit Primzahlordnung. Diese Voraussetzung wurde bei der Gruppe der Quadratischen Rest im Kapitel 5.4.2.1 Nachrichtenumwandlung vergessen.

Ein konkretes Gegenbeispiel ist sonst ℤ/13ℤ. Dort gibt es die 6 Quadrate {1,4,9,3,10,12}, aber beispielsweise 3 hat nur Ordnung 3, denn 3^3=27 ≡ 1 (mod 13).