### PR TITLE
Fehler beim kleiner Satz von Fermat

### DIFF
--- a/a-gruppen.tex
+++ b/a-gruppen.tex
@@ -154,7 +154,7 @@ kleine Satz von Fermat verwendet:
  \begin{theorem}[Kleiner Satz von Fermat]
    Sei $(\G, \cdot)$ eine Gruppe, $a \in \Z{}$ und $p$ eine
    Primzahl. Dann gilt
-   \[a^{p-1} \equiv 1 \mod p\]
+   \[a^{p} \equiv a \mod p\]
  \end{theorem}
 \section{Zyklische Gruppen}\index{zyklische Gruppe}\index{Gruppe!zyklische}
 Eine zyklische Gruppe hat die Eigenschaft, dass es mindestens einen


### PR DESCRIPTION
Die vorherige Variante des Satzes gilt nur, wenn der ggT(a,p)=1 ist.